### PR TITLE
"throw-if-not" accidentally throws IllegalArgumentExceptions

### DIFF
--- a/src/com/evocomputing/colors.clj
+++ b/src/com/evocomputing/colors.clj
@@ -73,7 +73,7 @@ http://cran.r-project.org/web/packages/colorspace/index.html
   for throwf."
   [test & args]
   (when-not test
-    (throw (Exception. args))))
+    (throw (Exception. (apply format args)))))
 
 (defn hexstring-to-rgba-int
   [hexstr]


### PR DESCRIPTION
eval this in repl.  the luminosity value is out of range.
(create-color {:h 1.0 :s 1.0 :l 111.0})

Before this change, the exception was thrown:
"IllegalArgumentException No matching ctor found for class java.lang.Exception  clojure.lang.Reflector.invokeConstructor (Reflector.java:183)"

Exception has no constructor which takes a clojure.lang.ArraySeq, and it is an ArraySeq which is being passed to the Exception constructor.

After the change, the exception thrown is:
"Exception Elements must be of the form:
H (Hue): Float value in the range of: 0.0 - 360.0
S (Saturation): Float value in the range: 0.0 - 100.0
L (Lightness or Luminance): Float value in the range 0.0 - 100.0
1.0 1.0 111.0  sun.reflect.NativeConstructorAccessorImpl.newInstance0 (NativeConstructorAccessorImpl.java:-2)"

Much better...
