### PR TITLE
Fix creation from RGB

### DIFF
--- a/src/com/evocomputing/colors.clj
+++ b/src/com/evocomputing/colors.clj
@@ -601,4 +601,4 @@ http://en.wikipedia.org/wiki/Luminance-Hue-Saturation#Conversion_from_RGB_to_HSL
             (= max min) 0.0
             (< l 0.5) (/ delta (* 2 l))
             :else (/ delta (- 2 (* 2 l))))]
-        [(mod h 360.0) (* 100.0 s) (* 100.0 l)]))
+        [(mod h 360.0) (clamp-percent-float (* 100.0 s)) (clamp-percent-float (* 100.0 l))]))

--- a/test/com/evocomputing/test/colors.clj
+++ b/test/com/evocomputing/test/colors.clj
@@ -69,7 +69,14 @@
   )
 
 
-(defn hsl-rgb-test-pairs []
+;; Make sure that creating a color from RGB values leads to legal
+;; saturation and lightness levels. These test values were
+;; formerly causing exceptions by yielding saturation or lightness
+;; values slightly greater than 100.0.
+(deftest test-rgb-color-creation
+  (adjust-hue (create-color :r 10 :g 255 :b 43) 40)
+  (adjust-hue (create-color :r 115 :g 255 :b 218) 40)
+  (adjust-hue (create-color :r 250 :g 255 :b 121) 40))(defn hsl-rgb-test-pairs []
   (let [filestr (slurp (.getPath (.getResource (clojure.lang.RT/baseLoader) "hsl-rgb.txt")))
         chunks (s/split filestr #"\n\n")
         clean-fn (fn [lines] (filter #(not= "" %) (map #(.trim %) (s/split lines #"\n"))))]
@@ -105,3 +112,4 @@
                         "Saturations should be equal")
           (throw-if-not (within-tolerance? (lightness hsl-color) (lightness rgb-color))
                         "Lightnesses should be equal")))))
+

--- a/test/com/evocomputing/test/colors.clj
+++ b/test/com/evocomputing/test/colors.clj
@@ -76,7 +76,9 @@
 (deftest test-rgb-color-creation
   (adjust-hue (create-color :r 10 :g 255 :b 43) 40)
   (adjust-hue (create-color :r 115 :g 255 :b 218) 40)
-  (adjust-hue (create-color :r 250 :g 255 :b 121) 40))(defn hsl-rgb-test-pairs []
+  (adjust-hue (create-color :r 250 :g 255 :b 121) 40))
+
+(defn hsl-rgb-test-pairs []
   (let [filestr (slurp (.getPath (.getResource (clojure.lang.RT/baseLoader) "hsl-rgb.txt")))
         chunks (s/split filestr #"\n\n")
         clean-fn (fn [lines] (filter #(not= "" %) (map #(.trim %) (s/split lines #"\n"))))]


### PR DESCRIPTION
I was seeing mysterious exceptions in the lighting control program I’m writing, and narrowed them down to the fact that sometimes when I called `create-color` with RGB values, I would end up with a color that could not be passed to `adjust-hue` without causing an exception. Certain legal RGB colors (it seems especially ones with values of 255 for green) end up with computed saturation or lightness values that are ever so slightly greater than 100.0, which causes problems when later manipulating the color.

This pull request adds a test which demonstrates the problem, and introduces a fix by clamping the calculated saturation and lightness levels to an upper bound of 100.0.