### PR TITLE
Fix issues reported by lein eastwood

### DIFF
--- a/src/com/evocomputing/colors/palettes/color_brewer.clj
+++ b/src/com/evocomputing/colors/palettes/color_brewer.clj
@@ -56,7 +56,7 @@
 (ns com.evocomputing.colors.palettes.color-brewer
   (:use [com.evocomputing.colors :only (create-color)])
   (:require
-   [clojure.core.string :as s]))
+   [clojure.string :as s]))
 
 
 (declare color-brewer-palettes)

--- a/src/com/evocomputing/colors/palettes/core.clj
+++ b/src/com/evocomputing/colors/palettes/core.clj
@@ -13,8 +13,9 @@
   (:use [com.evocomputing.colors :only (create-color)]))
 
 
-(defn inclusive-seq [n start end]
-  "Return n evenly spaced points along the range start - end (inclusive)"
+(defn inclusive-seq
+  "Return n evenly spaced points along the range start - end (inclusive)."
+  [n start end]
   (assert (< n 1)
   (condp = n
     1 [start]
@@ -110,10 +111,10 @@ be increased (1 = linear, 2 = quadratic, etc.)
          (inclusive-seq numcolors 1.0 0.0))))
 
 (defn heat-hsl
-  " Create heat palette in HSL space. By default, it goes from a red to a yellow hue, while
-simultaneously going to lighter colors (i.e., increasing
-lightness) and reducing the amount of color (i.e., decreasing
-saturation).
+  "Create heat palette in HSL space. By default, it goes from a red to
+  a yellow hue, while simultaneously going to lighter colors (i.e.,
+  increasing lightness) and reducing the amount of color (i.e.,
+  decreasing saturation).
 
 Arguments:
 numcolors: Number of colors to be produced in this palette.
@@ -139,7 +140,7 @@ be increased (1 = linear, 2 = quadratic, etc.)
         diff-h (- (:h-end opts) (:h-start opts))
         diff-s (- (:s-end opts) (:s-start opts))
         diff-l (- (:l-end opts) (:l-start opts))]
-    (map #(create-color :h (- (:h-end opts) (* (- diff-h %)))
+    (map #(create-color :h (- (:h-end opts) (* (- diff-h) %))
                         :s (- (:s-end opts) (* diff-s (Math/pow % (:power-saturation opts))))
                         :l (- (:l-end opts) (* diff-l (Math/pow % (:power-lightness opts)))))
          (inclusive-seq numcolors 1.0 0.0))))


### PR DESCRIPTION
There are really two parts to this pull request, since you merged my last one before I could fix something in it.

The main thrust is to fix some things that the Eastwood linter found, namely another misplaced docstring in inclusive-seq, and what appears to have been an actual bug in heat-hsl:

```
    == Linting com.evocomputing.colors.palettes.core ==
    {:linter :misplaced-docstrings,
     :msg "Possibly misplaced docstring, inclusive-seq",
      :file "com/evocomputing/colors/palettes/core.clj",
       :line 16,
        :column 7}
    
    {:linter :suspicious-expression,
     :msg
      "* called with 1 args.  (* x) always returns x.  Perhaps there are
      misplaced parentheses?",
       :file "com/evocomputing/colors/palettes/core.clj",
        :line 142,
         :column 45}
```

But this also fixes an inconsistent reference to the old location of the string library which snuck in as I jumped back and forth between versions. Clojure 1.7 is in release candidate stage, so hopefully we can stop doing that soon and I can release all my changes!
