### PR TITLE
Allow hsl creation with integers

### DIFF
--- a/src/com/evocomputing/colors.clj
+++ b/src/com/evocomputing/colors.clj
@@ -375,7 +375,7 @@ Multiple Arg
 (defmethod create-color ::hsl-map [hsl-map & others]
   (let [hsl-map (if others (apply assoc {} (vec (conj others hsl-map))) hsl-map)
         ks (keys hsl-map)
-        hsl (check-hsl (into [] (map #(hsl-map %)
+        hsl (check-hsl (into [] (map #(float (hsl-map %))
                                      (map #(some % ks)
                                           '(#{:h :hue} #{:s :saturation} #{:l :lightness})))))
         rgb (hsl-to-rgb (hsl 0) (hsl 1) (hsl 2))

--- a/src/com/evocomputing/colors/palettes/core.clj
+++ b/src/com/evocomputing/colors/palettes/core.clj
@@ -13,8 +13,9 @@
   (:use [com.evocomputing.colors :only (create-color)]))
 
 
-(defn inclusive-seq [n start end]
-  "Return n evenly spaced points along the range start - end (inclusive)"
+(defn inclusive-seq
+  "Return n evenly spaced points along the range start - end (inclusive)."
+  [n start end]
   (assert (< n 1)
   (condp = n
     1 [start]
@@ -139,7 +140,7 @@ be increased (1 = linear, 2 = quadratic, etc.)
         diff-h (- (:h-end opts) (:h-start opts))
         diff-s (- (:s-end opts) (:s-start opts))
         diff-l (- (:l-end opts) (:l-start opts))]
-    (map #(create-color :h (- (:h-end opts) (* (- diff-h %)))
+    (map #(create-color :h (- (:h-end opts) (* (- diff-h) %))
                         :s (- (:s-end opts) (* diff-s (Math/pow % (:power-saturation opts))))
                         :l (- (:l-end opts) (* diff-l (Math/pow % (:power-lightness opts)))))
          (inclusive-seq numcolors 1.0 0.0))))

--- a/src/com/evocomputing/colors/palettes/core.clj
+++ b/src/com/evocomputing/colors/palettes/core.clj
@@ -13,9 +13,8 @@
   (:use [com.evocomputing.colors :only (create-color)]))
 
 
-(defn inclusive-seq
-  "Return n evenly spaced points along the range start - end (inclusive)."
-  [n start end]
+(defn inclusive-seq [n start end]
+  "Return n evenly spaced points along the range start - end (inclusive)"
   (assert (< n 1)
   (condp = n
     1 [start]
@@ -140,7 +139,7 @@ be increased (1 = linear, 2 = quadratic, etc.)
         diff-h (- (:h-end opts) (:h-start opts))
         diff-s (- (:s-end opts) (:s-start opts))
         diff-l (- (:l-end opts) (:l-start opts))]
-    (map #(create-color :h (- (:h-end opts) (* (- diff-h) %))
+    (map #(create-color :h (- (:h-end opts) (* (- diff-h %)))
                         :s (- (:s-end opts) (* diff-s (Math/pow % (:power-saturation opts))))
                         :l (- (:l-end opts) (* diff-l (Math/pow % (:power-lightness opts)))))
          (inclusive-seq numcolors 1.0 0.0))))

--- a/test/com/evocomputing/test/colors.clj
+++ b/test/com/evocomputing/test/colors.clj
@@ -55,6 +55,8 @@
   (is (= :com.evocomputing.colors/color (type (create-color :r 255 :g 0 :blue 0 :a 255))))
   (is (= :com.evocomputing.colors/color (type (create-color {:h 120.0 :s 100.0 :l 50.0}))))
   (is (= :com.evocomputing.colors/color (type (create-color :h 120.0 :s 100.0 :l 50.0))))
+  (is (= :com.evocomputing.colors/color (type (create-color :h 120 :s 100 :l 50))))
+  (is (pos? (count (with-out-str (print (create-color :h 120 :s 100 :l 50))))))
   (is (= :com.evocomputing.colors/color (type (create-color (Color. 255 0 0)))))
   ;; test bad input checking
   (is (thrown? Exception (create-color "#badhexstring")))


### PR DESCRIPTION
This is a small change to fix something which had confused me quite a bit during this past week.

Formerly, if you accidentally passed integers for the saturation or lightness values when creating a color using an	HSL map, the color would create fine, but then when anything tried to print it (for example,
looking at a structure containing it in the REPL), an exception would be thrown, because the format string for printing the color was expecting a float.

This change adds a test	which reveals that exception, and then adds a fix which allows you to	pass integers for HSL components, and explicitly promotes them to floats during the construction process, which is more consistent with	other aspects of the Clojure ecosystem,	and certainly
less astonishing than having colors which seem to work until you try to
print them.