### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,9 @@
-(defproject com.evocomputing/colors
+(defproject org.clojars.brunchboy/colors
   "1.0.2-SNAPSHOT"
   :description "Utilities for color manipulations.
 This is mostly code ported from  the color module in SASS."
+  :url "http://jolby.github.com/colors/"
+  :license "Eclipse Public License (EPL)"
   :dependencies [[org.clojure/clojure "1.7.0-beta3"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/core.incubator "0.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject org.clojars.brunchboy/colors
-  "1.0.2-SNAPSHOT"
+(defproject com.evocomputing/colors
+  "1.0.2"
   :description "Utilities for color manipulations.
 This is mostly code ported from  the color module in SASS."
   :url "http://jolby.github.com/colors/"
   :license "Eclipse Public License (EPL)"
-  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/core.incubator "0.1.3"]]
 
@@ -14,9 +14,9 @@ This is mostly code ported from  the color module in SASS."
             :copyright "Eclipse Public License (EPL)"
             :web-src-dir "http://github.com/jolby/colors/blob/"
             :web-home "http://jolby.github.com/colors/"}
-  :plugins [[lein-ancient "0.6.5"]
+  :plugins [[lein-ancient "0.6.7"]
             [codox "0.8.12"]]
-  :codox {:src-dir-uri "http://github.com/brunchboy/colors/blob/master/"
+  :codox {:src-dir-uri "https://github.com/jolby/colors/blob/master/"
           :src-linenum-anchor-prefix "L"
           :output-dir "target/doc"}
   :min-lein-version "2.0.0")

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject com.evocomputing/colors
-  "1.0.1-SNAPSHOT"
+  "1.0.2-SNAPSHOT"
   :description "Utilities for color manipulations.
 This is mostly code ported from  the color module in SASS."
   :dependencies [[org.clojure/clojure "1.7.0-beta3"]

--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,19 @@
   "1.0.1-SNAPSHOT"
   :description "Utilities for color manipulations.
 This is mostly code ported from  the color module in SASS."
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/math.numeric-tower "0.0.3"]
-                 [org.clojure/core.incubator "0.1.3"]]
+  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
+                                  [org.clojure/core.incubator "0.1.3"]]
 
   :autodoc { :name "colors"
             :description "Color and colorspace calculation, manipulation and conversion in Clojure."
             :page-title "Colors API documentation"
             :copyright "Eclipse Public License (EPL)"
             :web-src-dir "http://github.com/jolby/colors/blob/"
-            :web-home "http://jolby.github.com/colors/"})
+            :web-home "http://jolby.github.com/colors/"}
+  :plugins [[lein-ancient "0.6.5"]
+            [codox "0.8.12"]]
+  :codox {:src-dir-uri "http://github.com/brunchboy/colors/blob/master/"
+          :src-linenum-anchor-prefix "L"
+          :output-dir "target/doc"}
+  :min-lein-version "2.0.0")

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 This is mostly code ported from  the color module in SASS."
   :dependencies [[org.clojure/clojure "1.7.0-beta3"]
                  [org.clojure/math.numeric-tower "0.0.4"]
-                                  [org.clojure/core.incubator "0.1.3"]]
+                 [org.clojure/core.incubator "0.1.3"]]
 
   :autodoc { :name "colors"
             :description "Color and colorspace calculation, manipulation and conversion in Clojure."


### PR DESCRIPTION
All right! Clojure 1.7 has been final for a while now and appears to be working great, and performs noticeably better than 1.6 (which performed way better than the last version this was built against). Since I am getting ready to cut my first release of Afterglow, I am hoping that you will be willing to cut a non-snapshot release of Colors with these updates, so I can refer to that authoritative release, rather than to a fork of my own.

Also included in this pull request are a couple of Leiningen plugins, which will require you to be on Leiningen version 2.0, but will make it easier for you to keep up to date on dependencies (by running `lein ancient`) and will also allow you to generate nicer API documentation using `lein codox` rather than the abandoned autodoc plugin which you had previously been using. (When you do run codox, it will create the documentation files in `target/doc` and you will just need to move them to where you host them. They are already generating correct "view source" links to your source code on github.) Or if you prefer to stick with the old autodoc approach, that should not be broken by this change; it merely offers you the opportunity to update if you so desire. I find Codox tremendously useful, and have been using it for the API documentation of Afterglow.

Speaking of which, there are some screen shots and a photo about a third of the way down the project [Readme](https://github.com/brunchboy/afterglow) which show Colors at work, adjusting lightness values within the web cue grid and on the Ableton Push to reflect the colors assigned to cues, and whether they are currently active or compatible with other running cues. Admittedly not as cool as seeing Colors generating actual light shows, but I have not yet had a chance to make a movie of a running show.