### PR TITLE
Eliminate obsolete dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,11 @@
 (defproject com.evocomputing/colors
-  "1.0.4"
+  "1.0.5"
   :description "Utilities for color manipulations.
 This is mostly code ported from  the color module in SASS."
   :url "http://jolby.github.com/colors/"
   :license "Eclipse Public License (EPL)"
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/math.numeric-tower "0.0.4"]
-                 [org.clojure/core.incubator "0.1.3"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/math.numeric-tower "0.0.4"]]
 
   :autodoc { :name "colors"
             :description "Color and colorspace calculation, manipulation and conversion in Clojure."
@@ -14,8 +13,7 @@ This is mostly code ported from  the color module in SASS."
             :copyright "Eclipse Public License (EPL)"
             :web-src-dir "http://github.com/jolby/colors/blob/"
             :web-home "http://jolby.github.com/colors/"}
-  :plugins [[lein-ancient "0.6.7"]
-            [codox "0.8.12"]]
+  :plugins [[codox "0.8.12"]]
   :codox {:src-dir-uri "https://github.com/jolby/colors/blob/master/"
           :src-linenum-anchor-prefix "L"
           :output-dir "target/doc"}

--- a/src/com/evocomputing/colors.clj
+++ b/src/com/evocomputing/colors.clj
@@ -34,9 +34,8 @@ http://cran.r-project.org/web/packages/colorspace/index.html
 
   com.evocomputing.colors
   (:import (java.awt Color))
-  (:use [clojure.math.numeric-tower :only [abs round]]
-        [clojure.core.incubator :only [seqable?]])
-  (:require [com.evocomputing.colors.palettes.webcolors :as wc]))
+  (:require [com.evocomputing.colors.palettes.webcolors :as wc]
+            [clojure.math.numeric-tower :refer [abs round]]))
 
 (declare rgb-int-to-components rgba-int-to-components
          rgb-int-from-components rgba-int-from-components

--- a/test/com/evocomputing/test/colors.clj
+++ b/test/com/evocomputing/test/colors.clj
@@ -11,7 +11,7 @@
 
 
 (ns com.evocomputing.test.colors
-  (import (java.awt Color))
+  (:import (java.awt Color))
   (:use (clojure test))
   (:use (com.evocomputing colors))
   (:require [clojure.string :as s]))
@@ -116,4 +116,3 @@
                         "Saturations should be equal")
           (throw-if-not (within-tolerance? (lightness hsl-color) (lightness rgb-color))
                         "Lightnesses should be equal")))))
-


### PR DESCRIPTION
The `seqable?` function is now part of clojure.core, so including this older version from clojure.contrib is causing compile-time warnings.

This also eliminates the need to depend on clojure.contrib at all.

I also removed `lein-ancient` from the project plugins. The version referenced crashes with current Java and Clojure distributions, and this tool is something that better fits in an individual's `~/.lein/profiles.clj` rather than in the project definition.